### PR TITLE
allow session() to request a subtree of info

### DIFF
--- a/pwnagotchi/bettercap.py
+++ b/pwnagotchi/bettercap.py
@@ -31,8 +31,10 @@ class Client(object):
         self.websocket = "ws://%s:%s@%s:%d/api" % (username, password, hostname, port)
         self.auth = HTTPBasicAuth(username, password)
 
-    def session(self):
-        r = requests.get("%s/session" % self.url, auth=self.auth)
+    # session takes optional argument to pull a sub-dictionary
+    #  ex.: "session/wifi", "session/ble"
+    def session(self, sess="session"):
+        r = requests.get("%s/%s" % (self.url, sess), auth=self.auth)
         return decode(r)
 
     async def start_websocket(self, consumer):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
allow pwnagotchi to make partial requests from bettercap

## Description
<!--- Describe your changes in detail -->
added optional parameter to bettercap.session() that limits the data request to a subtree of the total
data.  "session" is default behavior of dumping everything.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))
The default behavior sends back a lot of information. It includes all of the caplets and everything. Allowing requests for just the wifi section would reduce the amount of data pwnagotchi and bettercap are passing around all the time. It makes the requests more efficient.  Most of the time its only looking for wifi anyway.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested for months on active pwnagotchi.  Used in bcinfo.py (Sniffleupagus/pwnagotchi-utils) for just fetching wifi stats.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
