### PR TITLE
make throttle time for associate and deauth configurable

### DIFF
--- a/pwnagotchi/agent.py
+++ b/pwnagotchi/agent.py
@@ -400,10 +400,13 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
 
         return self._history[who] < self._config['personality']['max_interactions']
 
-    def associate(self, ap, throttle=0):
+    def associate(self, ap, throttle=-1):
         if self.is_stale():
             logging.debug("recon is stale, skipping assoc(%s)", ap['mac'])
             return
+
+        if throttle == -1 and "throttle_a" in self._config['personality']:
+            throttle = self._config['personality']['throttle_a']
 
         if self._config['personality']['associate'] and self._should_interact(ap['mac']):
             self._view.on_assoc(ap)
@@ -421,10 +424,13 @@ class Agent(Client, Automata, AsyncAdvertiser, AsyncTrainer):
                 time.sleep(throttle)
             self._view.on_normal()
 
-    def deauth(self, ap, sta, throttle=0):
+    def deauth(self, ap, sta, throttle=-1):
         if self.is_stale():
             logging.debug("recon is stale, skipping deauth(%s)", sta['mac'])
             return
+
+        if throttle == -1 and "throttle_d" in self._config['personality']:
+            throttle = self._config['personality']['throttle_d']
 
         if self._config['personality']['deauth'] and self._should_interact(sta['mac']):
             self._view.on_deauth(sta)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
make throttle for associate and deauth configurable

## Description
<!--- Describe your changes in detail -->

changed default value of throttle parameter of both associate() and deauth() to -1. If not set when calling the function,  it will try looking in config[] (from config.toml), and use values from there.

Add to config.toml:

personality.throttle_a = 0.4
personality.throttle_d = 0.9

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

Unthrottled packet injection seems to make the nexmon driver crash. Adding short delays between "attacks" keeps the driver running longer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on multiple pwnagotchi over several months. If throttles are set to 0, or left out of config.toml, the pwnagotchi crashes pretty often. Adding throttles as above makes it a lot more stable.

With throttles set to 0, or not in config.toml, behavior of pwnagotchi is the same as without this feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
