### PR TITLE
Graceful ai fail

### DIFF
--- a/pwnagotchi/ai/__init__.py
+++ b/pwnagotchi/ai/__init__.py
@@ -24,6 +24,15 @@ def load(config, agent, epoch, from_disk=True):
             from stable_baselines3 import A2C
             logging.debug("[ai] A2C imported in %.2fs" % (time.time() - start))
 
+            # remove ai.params that are invalid for SB3 A2C, but used in old SB
+            try:
+                for key in [ 'alpha', 'epsilon', 'lr_schedule' ]:
+                    if key in config['params']:
+                        logging.info("Removing ai parameter %s" % key);
+                        del config['params'][key]
+            except Exception as err:
+                logging.warn(repr(err))
+
             start = time.time()
             from stable_baselines3.a2c import MlpPolicy
             logging.debug("[ai] MlpPolicy imported in %.2fs" % (time.time() - start))

--- a/pwnagotchi/ai/__init__.py
+++ b/pwnagotchi/ai/__init__.py
@@ -28,7 +28,7 @@ def load(config, agent, epoch, from_disk=True):
             try:
                 for key in [ 'alpha', 'epsilon', 'lr_schedule' ]:
                     if key in config['params']:
-                        logging.info("Removing ai parameter %s" % key);
+                        logging.info("Removing legacy ai parameter %s" % key);
                         del config['params'][key]
             except Exception as err:
                 logging.warn(repr(err))
@@ -45,19 +45,22 @@ def load(config, agent, epoch, from_disk=True):
         except Exception as e:
             logging.debug("[ai] stable_baselines3 not accessible. Trying stable_baselines")
 
-            from stable_baselines import A2C
-            logging.debug("[ai] A2C imported in %.2fs" % (time.time() - start))
-            SB_BACKEND = "stable_baselines"
+            try:
+                from stable_baselines import A2C
+                logging.debug("[ai] A2C imported in %.2fs" % (time.time() - start))
+                SB_BACKEND = "stable_baselines"
 
-            start = time.time()
-            from stable_baselines.common.policies import MlpLstmPolicy
-            logging.debug("[ai] MlpLstmPolicy imported in %.2fs" % (time.time() - start))
-            SB_A2C_POLICY = MlpLstmPolicy
+                start = time.time()
+                from stable_baselines.common.policies import MlpLstmPolicy
+                logging.debug("[ai] MlpLstmPolicy imported in %.2fs" % (time.time() - start))
+                SB_A2C_POLICY = MlpLstmPolicy
 
-            start = time.time()
-            from stable_baselines.common.vec_env import DummyVecEnv
-            logging.debug("[ai] DummyVecEnv imported in %.2fs" % (time.time() - start))
-
+                start = time.time()
+                from stable_baselines.common.vec_env import DummyVecEnv
+                logging.debug("[ai] DummyVecEnv imported in %.2fs" % (time.time() - start))
+            except Exception as e:
+                logging.debug("[ai] failed to load AI. %s\n Remaining in AUTO" % repr(e))
+                return False
 
         start = time.time()
         import pwnagotchi.ai.gym as wrappers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Gracefully fail if neither version of stable_baselines is available.
also deletes the old AI parameters from config, if they are present from an old
config file.

## Description
<!--- Describe your changes in detail -->
Instead of causing an error if AI libraries are unavailable (on platforms that do not support torch or tensor flow), catch the error and continue in AUTO mode. Basically wrapped the "import stable_baselines" the same way as "import stable_baselines3".

If stable baselines 3 does load, delete any old ai parameters from config in memory.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))

Improve compatibility with old config files (that have the old parameters in them) as people convert from older pwnagotchi to the new.

And automatically handle systems that do not have stable baselines available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the first by adding the parameters back to default.toml, and it works fine.  Tested the stable baselines fall-through on a bananapim2zero with no torch or tensor flow libraries available.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
