### PR TITLE
adding an identity backup

### DIFF
--- a/pwnagotchi/identity.py
+++ b/pwnagotchi/identity.py
@@ -27,7 +27,7 @@ class KeyPair(object):
             # first time, generate new keys
             if not os.path.exists(self.priv_path) or not os.path.exists(self.pub_path):
                 if os.path.exists(f'{self.priv_path}.original') and os.path.exists(f'{self.pub_path}.original') and os.path.exists(f'{self.fingerprint_path}.original'):
-                    logging.warning('laoding backup')
+                    logging.warning('loading backup')
                     shutil.copy(f'{self.priv_path}.original', self.priv_path)
                     shutil.copy(f'{self.pub_path}.original', self.pub_path)
                 else:


### PR DESCRIPTION
## Description
A backup is created when the keys and fingerprint are generated. If the files are corrupted, the backups are loaded instead of a regenerate it. The pwnagotchi is protected.

## Motivation and Context
In some crash cases, the key can be corrupted and the keys need to be generated again. 
[Pwnagotchi's identity protection commit](https://github.com/evilsocket/pwnagotchi/issues/1197)
- [X] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
It's already integrated since a while into fancygotchi. It served me well for all the crashed I caused while I developed my new features. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
